### PR TITLE
Hotfix: gallery-list-item .is method (actual)

### DIFF
--- a/src/components/gallery/gallery-list-item.js
+++ b/src/components/gallery/gallery-list-item.js
@@ -86,4 +86,4 @@ class GalleryListItem extends connect(store)(LitElement) {
   }
 }
 
-window.customElements.define(GalleryListItem, GalleryListItem);
+window.customElements.define(GalleryListItem.is, GalleryListItem);


### PR DESCRIPTION
Somehow missed staging this hotfix