### PR TITLE
Enable Sentry in Prod again

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,6 @@
 
     <!-- Any external scripts -->
     <script src="https://js.stripe.com/v3/"></script>
-    <script src="https://browser.sentry-cdn.com/4.4.2/bundle.min.js" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/tiff.js@1.0.0/tiff.min.js" crossorigin="anonymous"></script>
 
     <!-- Load webcomponents-loader.js to check and load any polyfills your browser needs -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -711,6 +711,75 @@
       "integrity": "sha512-tLX8tFE4mkc4p84YG5239G0hbgTVv2irZYrSyO0OblUqIRbRoCPmbydm3HRFQkJeAB3rPCtyeZ2roJULsmTG3A==",
       "dev": true
     },
+    "@sentry/browser": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.2.1.tgz",
+      "integrity": "sha512-OAikFZ9EimD3noxMp8tA6Cf6qJcQ2U8k5QSgTPwdx+09nZOGJzbRFteK7WWmrS93ZJdzN61lpSQbg5v+bmmfbQ==",
+      "requires": {
+        "@sentry/core": "6.2.1",
+        "@sentry/types": "6.2.1",
+        "@sentry/utils": "6.2.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.1.tgz",
+      "integrity": "sha512-jPqQEtafxxDtLONhCbTHh/Uq8mZRhsfbwJTSVYfPVEe/ELfFZLQK7tP6rOh7zEWKbTkE0mE6XcaoH3ZRAhgrqg==",
+      "requires": {
+        "@sentry/hub": "6.2.1",
+        "@sentry/minimal": "6.2.1",
+        "@sentry/types": "6.2.1",
+        "@sentry/utils": "6.2.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.1.tgz",
+      "integrity": "sha512-pG7wCQeRpzeP6t0bT4T0X029R19dbDS3/qswF8BL6bg0AI3afjfjBAZm/fqn1Uwe/uBoMHVVdbxgJDZeQ5d4rQ==",
+      "requires": {
+        "@sentry/types": "6.2.1",
+        "@sentry/utils": "6.2.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.1.tgz",
+      "integrity": "sha512-wuSXB4Ayxv9rBEQ4pm7fnG4UU2ZPtPnnChoEfd4/mw1UthXSvmPFEn6O4pdo2G8fTkl8eqm6wT/Q7uIXMEmw+A==",
+      "requires": {
+        "@sentry/hub": "6.2.1",
+        "@sentry/types": "6.2.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/tracing": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.2.1.tgz",
+      "integrity": "sha512-bvStY1SnL08wkSeVK3j9K5rivQQJdKFCPR2VYRFOCaUoleZ6ChPUnBvxQ/E2LXc0hk/y/wo1q4r5B0dfCCY+bQ==",
+      "requires": {
+        "@sentry/hub": "6.2.1",
+        "@sentry/minimal": "6.2.1",
+        "@sentry/types": "6.2.1",
+        "@sentry/utils": "6.2.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.1.tgz",
+      "integrity": "sha512-h0OV1QT+fv5ojfK5/+iEXClu33HirmvbjcQC2jf05IHj9yXIOWy6EB10S8nBjuLiiFqQiAQYj3FN9Ip4eN8NJA=="
+    },
+    "@sentry/utils": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.1.tgz",
+      "integrity": "sha512-6kQgM/yBPdXu+3qbJnI6HBcWztN9QfiMkH++ZiKk4ERhg9d2LYWlze478uTU5Fyo/JQYcp+McpjtjpR9QIrr0g==",
+      "requires": {
+        "@sentry/types": "6.2.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -24690,8 +24759,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "dependencies": {
     "@material/mwc-icon": "^0.3.4",
     "@polymer/lit-element": "^0.6.4",
+    "@sentry/browser": "^6.2.1",
+    "@sentry/tracing": "^6.2.1",
     "@webcomponents/webcomponentsjs": "^2.2.1",
     "aws-sdk": "^2.395.0",
     "dedent": "^0.7.0",

--- a/server/src/routes.mjs
+++ b/server/src/routes.mjs
@@ -328,7 +328,7 @@ export async function env(ctx) {
     env: {
       STRIPE_PK: process.env.STRIPE_PK,
       SENTRY_DSN: process.env.SENTRY_DSN,
-      SENTRY_ENABLE: process.env.SENTRY_ENABLE === 'TRUE',
+      SENTRY_ENABLE: process.env.SENTRY_ENABLE === 'true',
       PUSH_PUBKEY: process.env.PUSH_PUBKEY
     }
   }

--- a/src/components/zuzi-app/index.js
+++ b/src/components/zuzi-app/index.js
@@ -9,6 +9,8 @@ import { installMediaQueryWatcher } from 'pwa-helpers/media-query.js';
 import { installOfflineWatcher } from 'pwa-helpers/network.js';
 import { installRouter } from 'pwa-helpers/router.js';
 import { updateMetadata } from 'pwa-helpers/metadata.js';
+import * as Sentry from "@sentry/browser"
+import { Integrations } from "@sentry/tracing"
 
 // This element is connected to the Redux store.
 import { store, connect } from '../../store.js';
@@ -266,7 +268,11 @@ class ZuziApp extends connect(store)(LitElement) {
     }
 
     if ( process.env.SENTRY_ENABLE ) {
-      Sentry.init({ dsn: process.env.SENTRY_DSN });
+      Sentry.init({
+        dsn: process.env.SENTRY_DSN,
+        integrations: [new Integrations.BrowserTracing()],
+        tracesSampleRate: 1.0
+      });
     }
   }
 


### PR DESCRIPTION
This updates and enables sentry in production again. The trace sample rate is set to 1.0, meaning _all_ events are sent to sentry.