### PR TITLE
fix connection failures with atlas in dev

### DIFF
--- a/k8s/server.deployment.yaml
+++ b/k8s/server.deployment.yaml
@@ -50,3 +50,4 @@ spec:
         - name: mongodb-creds
           secret:
             secretName: mongodb-admin-koa
+            optional: true

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -72,18 +72,19 @@ export const db_connect = (server) => {
                 }
             );
         } catch (error) {
-            if (error.code in ['EACCES', 'ENOENT', 'EPERM']) {
+            if (['EACCES', 'ENOENT', 'EPERM'].includes(error.code)) {
                 await mongoose.connect(
                     process.env.MONGO_URL,
                     {
-                        user: process.env.MONGO_USER,
-                        pass: process.env.MONGO_PW,
+                        auth: {
+                            user: process.env.MONGO_USER,
+                            password: process.env.MONGO_PW
+                        },
                         dbName: process.env.MONGO_DBNAME,
-                        authSource: process.env.MONGO_AUTHSOURCE,
                         useNewUrlParser: true,
                         useUnifiedTopology: true
                     }
-                    );
+                );
             } else {
                 throw error
             }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -32,23 +32,36 @@ deploy:
 profiles:
   - name: dev
     patches:
+        # Set the namespace to zuzi-dev
       - op: replace
         path: /deploy/kubectl/defaultNamespace
         value: zuzi-dev
+
+        # Target the dev config
       - op: replace
         path: /deploy/kubectl/manifests/0
         value: k8s/dev/namespace.yaml
+
+        # Target the dev config
       - op: replace
         path: /deploy/kubectl/manifests/1
         value: k8s/dev/env.secret.yaml
+        
+        # Target the dev config
       - op: replace
         path: /deploy/kubectl/manifests/2
         value: k8s/dev/ingress.yaml
+
+        # Don't deploy mongo - using mlab here
       - op: remove
         path: /deploy/kubectl/manifests/7
+
+        # Docker build target is the dev image
       - op: replace
         path: /build/artifacts/0/docker/target
         value: dev
+
+        # Set sync config for fast reload 
       - op: replace
         path: /build/artifacts/0/sync
         value:
@@ -67,15 +80,22 @@ profiles:
 
   - name: prod
     patches:
+      # Set the prod namespace to zuzi-site
       - op: replace
         path: /deploy/kubectl/defaultNamespace
         value: zuzi-site
+
+        # Target the prod config
       - op: replace
         path: /deploy/kubectl/manifests/0
         value: k8s/prod/namespace.yaml
+
+        # Target the prod config
       - op: replace
         path: /deploy/kubectl/manifests/1
         value: k8s/prod/env.secret.yaml
+        
+        # Target the prod config
       - op: replace
         path: /deploy/kubectl/manifests/2
         value: k8s/prod/ingress.yaml


### PR DESCRIPTION
Mounting the mongodb operator secret volume should be optional to help with local dev, and membership testing in JS is done with `includes`, not `in` -- that'd be python.